### PR TITLE
feat: adding close campaign in remote manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ graph LR
 | Bundler | [`0x67346f8b9B7dDA4639600C190DDaEcDc654359c8`](https://arbiscan.io/address/0x67346f8b9B7dDA4639600C190DDaEcDc654359c8) | Arbitrum, Optimism, Base, Polygon |
 | L1Sender | [`0xD9b90F3Ab02077c21987c5fb9c4d1c5d2a10eC1C`](https://etherscan.io/address/0xD9b90F3Ab02077c21987c5fb9c4d1c5d2a10eC1C) | Mainnet |
 | L1BlockOracleUpdater | [`0x2292514B78799486D860a5f685c3270bcEf8E4b9`](https://arbiscan.io/address/0x2292514B78799486D860a5f685c3270bcEf8E4b9) | Arbitrum, Optimism, Base, Polygon |
+| CampaignRemoteManager | [`0x000000009dF57105d76B059178989E01356e4b45`](https://etherscan.io/address/0x000000009dF57105d76B059178989E01356e4b45) | Mainnet, Arbitrum, Optimism, Base, Polygon |
 
 #### Curve Implementation
 
 | Contract | Address | Networks |
 |----------|---------|----------|
-| CampaignRemoteManager | [`0xd1f0101Df22Cb7447F486Da5784237AB7a55eB4e`](https://etherscan.io/address/0xd1f0101Df22Cb7447F486Da5784237AB7a55eB4e) | Mainnet, Arbitrum, Optimism, Base, Polygon |
 | Votemarket | [`0x5e5C922a5Eeab508486eB906ebE7bDFFB05D81e5`](https://arbiscan.io/address/0x5e5C922a5Eeab508486eB906ebE7bDFFB05D81e5) | Arbitrum, Optimism, Base, Polygon |
 | Oracle | [`0x36F5B50D70df3D3E1c7E1BAf06c32119408Ef7D8`](https://arbiscan.io/address/0x36F5B50D70df3D3E1c7E1BAf06c32119408Ef7D8) | Arbitrum, Optimism, Base, Polygon |
 | Verifier | [`0x2Fa15A44eC5737077a747ed93e4eBD5b4960a465`](https://arbiscan.io/address/0x2Fa15A44eC5737077a747ed93e4eBD5b4960a465) | Arbitrum, Optimism, Base, Polygon |
@@ -86,7 +86,6 @@ graph LR
 
 | Contract | Address | Networks |
 |----------|---------|----------|
-| CampaignRemoteManager | [`0x000000006EA867a44FECbd5577D29d5173400c81`](https://etherscan.io/address/0x000000006EA867a44FECbd5577D29d5173400c81) | Mainnet, Arbitrum, Optimism, Base, Polygon |
 | Votemarket | [`0x00000000567E1FE94a27f64D50A1a15875182c3E`](https://arbiscan.io/address/0x00000000567E1FE94a27f64D50A1a15875182c3E) | Arbitrum, Optimism, Base, Polygon |
 | Oracle | [`0x000000009f42db5807378c374da13c54C856c29c`](https://arbiscan.io/address/0x000000009f42db5807378c374da13c54C856c29c) | Arbitrum, Optimism, Base, Polygon |
 | Verifier | [`0x00000000888Fb15FfbBa217F302a77FA0226Ce16`](https://arbiscan.io/address/0x00000000888Fb15FfbBa217F302a77FA0226Ce16) | Arbitrum, Optimism, Base, Polygon |
@@ -96,7 +95,6 @@ graph LR
 
 | Contract | Address | Networks |
 |----------|---------|----------|
-| CampaignRemoteManager | [`0x000000007254C9a1eBb8b0E9DF98A3b60BF29282`](https://etherscan.io/address/0x000000007254C9a1eBb8b0E9DF98A3b60BF29282) | Mainnet, Arbitrum, Optimism, Base, Polygon |
 | Votemarket | [`0x00000000EB9E04494FC17339f60EA4D26B2D727C`](https://arbiscan.io/address/0x00000000EB9E04494FC17339f60EA4D26B2D727C) | Arbitrum, Optimism, Base, Polygon |
 | Oracle | [`0x000000009271842F0D4Db92a7Ef5544D1F70bC1A`](https://arbiscan.io/address/0x000000009271842F0D4Db92a7Ef5544D1F70bC1A) | Arbitrum, Optimism, Base, Polygon |
 | Verifier | [`0x00000000c6906194269c9955A9E5DEF4e018CDd5`](https://arbiscan.io/address/0x00000000c6906194269c9955A9E5DEF4e018CDd5) | Arbitrum, Optimism, Base, Polygon |

--- a/packages/periphery/script/DeployRemoteManager.s.sol
+++ b/packages/periphery/script/DeployRemoteManager.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.19;
+
+import "@forge-std/src/Script.sol";
+import {CampaignRemoteManager} from "src/remote/CampaignRemoteManager.sol";
+
+interface ImmutableCreate2Factory {
+    function safeCreate2(bytes32, bytes memory) external;
+}
+
+contract DeployRemoteManager is Script {
+    address deployer = 0x8898502BA35AB64b3562aBC509Befb7Eb178D4df;
+
+    function run() public {
+        vm.createSelectFork("mainnet");
+        vm.startBroadcast(deployer);
+
+        bytes memory args = abi.encode(
+            0xF0000058000021003E4754dCA700C766DE7601C2,
+            0x96006425Da428E45c282008b00004a00002B345e,
+            0xB0552b6860CE5C0202976Db056b5e3Cc4f9CC765
+        );
+
+        ImmutableCreate2Factory factory = ImmutableCreate2Factory(0x0000000000FFe8B47B3e2130213B802212439497);
+
+        bytes32 initalizeCode = keccak256(abi.encodePacked(type(CampaignRemoteManager).creationCode, args));
+        console.logBytes32(initalizeCode);
+
+        address expectedAddress = 0x000000009dF57105d76B059178989E01356e4b45;
+        bytes32 salt = bytes32(0x8898502ba35ab64b3562abc509befb7eb178d4df75e47f6342d5279f66004005);
+
+        factory.safeCreate2(salt, abi.encodePacked(type(CampaignRemoteManager).creationCode, args));
+
+        vm.stopBroadcast();
+    }
+}

--- a/packages/periphery/src/remote/CampaignRemoteManager.sol
+++ b/packages/periphery/src/remote/CampaignRemoteManager.sol
@@ -272,7 +272,6 @@ contract CampaignRemoteManager is Ownable {
         if (sender != address(this)) revert InvalidSender();
 
         Payload memory _payload = abi.decode(payload, (Payload));
-        if (!whitelistedPlatforms[_payload.votemarket]) revert PlatformNotWhitelisted();
 
         if (_payload.actionType == ActionType.CREATE_CAMPAIGN) {
             CampaignCreationParams memory params = abi.decode(_payload.parameters, (CampaignCreationParams));

--- a/packages/periphery/src/remote/CampaignRemoteManager.sol
+++ b/packages/periphery/src/remote/CampaignRemoteManager.sol
@@ -61,9 +61,6 @@ contract CampaignRemoteManager is Ownable {
     /// @notice The La Poste address.
     address public immutable LA_POSTE;
 
-    /// @notice The Votemarket address on L2s.
-    address public immutable VOTEMARKET;
-
     /// @notice The token factory address.
     address public immutable TOKEN_FACTORY;
 
@@ -115,9 +112,8 @@ contract CampaignRemoteManager is Ownable {
         _;
     }
 
-    constructor(address _votemarket, address _laPoste, address _tokenFactory, address _owner) {
+    constructor(address _laPoste, address _tokenFactory, address _owner) {
         LA_POSTE = _laPoste;
-        VOTEMARKET = _votemarket;
         TOKEN_FACTORY = _tokenFactory;
 
         _initializeOwner(_owner);

--- a/packages/periphery/test/remote/CampaignRemoteManager.t.sol
+++ b/packages/periphery/test/remote/CampaignRemoteManager.t.sol
@@ -62,12 +62,12 @@ contract CampaignRemoteManagerTest is Test {
         vm.chainId(42161);
 
         vm.expectRevert(CampaignRemoteManager.InvalidChainId.selector);
-        campaignRemoteManager.createCampaign(params, 10, 100000);
+        campaignRemoteManager.createCampaign(params, 10, 100000, address(votemarket));
 
         vm.chainId(1);
 
         rewardToken.approve(address(campaignRemoteManager), 1000e18);
-        campaignRemoteManager.createCampaign(params, 10, 100000);
+        campaignRemoteManager.createCampaign(params, 10, 100000, address(votemarket));
 
         assertEq(rewardToken.balanceOf(address(this)), 0);
         assertEq(rewardToken.balanceOf(address(campaignRemoteManager)), 0);
@@ -87,10 +87,10 @@ contract CampaignRemoteManagerTest is Test {
 
         vm.chainId(42161);
         vm.expectRevert(CampaignRemoteManager.InvalidChainId.selector);
-        campaignRemoteManager.manageCampaign(managementParams, 10, 100000);
+        campaignRemoteManager.manageCampaign(managementParams, 10, 100000, address(votemarket));
 
         vm.chainId(1);
-        campaignRemoteManager.manageCampaign(managementParams, 10, 100000);
+        campaignRemoteManager.manageCampaign(managementParams, 10, 100000, address(votemarket));
 
         assertEq(rewardToken.balanceOf(address(this)), 0);
         assertEq(rewardToken.balanceOf(address(campaignRemoteManager)), 0);
@@ -103,10 +103,10 @@ contract CampaignRemoteManagerTest is Test {
 
         vm.chainId(42161);
         vm.expectRevert(CampaignRemoteManager.InvalidChainId.selector);
-        campaignRemoteManager.closeCampaign(params, 10, 100000);
+        campaignRemoteManager.closeCampaign(params, 10, 100000, address(votemarket));
 
         vm.chainId(1);
-        campaignRemoteManager.closeCampaign(params, 10, 100000);
+        campaignRemoteManager.closeCampaign(params, 10, 100000, address(votemarket));
     }
 
     function test_receiveMessage() public {
@@ -127,8 +127,9 @@ contract CampaignRemoteManagerTest is Test {
         bytes memory payload = abi.encode(
             CampaignRemoteManager.Payload({
                 actionType: CampaignRemoteManager.ActionType.CREATE_CAMPAIGN,
-                parameters: parameters,
-                sender: address(this)
+                sender: address(this),
+                votemarket: address(votemarket),
+                parameters: parameters
             })
         );
 
@@ -172,8 +173,9 @@ contract CampaignRemoteManagerTest is Test {
         bytes memory managementPayload = abi.encode(
             CampaignRemoteManager.Payload({
                 actionType: CampaignRemoteManager.ActionType.MANAGE_CAMPAIGN,
-                parameters: managementParameters,
-                sender: address(0xCAFE)
+                sender: address(0xCAFE),
+                votemarket: address(votemarket),
+                parameters: managementParameters
             })
         );
 
@@ -193,8 +195,9 @@ contract CampaignRemoteManagerTest is Test {
         managementPayload = abi.encode(
             CampaignRemoteManager.Payload({
                 actionType: CampaignRemoteManager.ActionType.MANAGE_CAMPAIGN,
-                parameters: managementParameters,
-                sender: address(this)
+                sender: address(this),
+                votemarket: address(votemarket),
+                parameters: managementParameters
             })
         );
 
@@ -240,8 +243,9 @@ contract CampaignRemoteManagerTest is Test {
         bytes memory createPayload = abi.encode(
             CampaignRemoteManager.Payload({
                 actionType: CampaignRemoteManager.ActionType.CREATE_CAMPAIGN,
-                parameters: createParameters,
-                sender: address(this)
+                sender: address(this),
+                votemarket: address(votemarket),
+                parameters: createParameters
             })
         );
 
@@ -262,8 +266,9 @@ contract CampaignRemoteManagerTest is Test {
         bytes memory closePayload = abi.encode(
             CampaignRemoteManager.Payload({
                 actionType: CampaignRemoteManager.ActionType.CLOSE_CAMPAIGN,
-                parameters: closeParameters,
-                sender: address(this)
+                sender: address(0xCAFE),
+                votemarket: address(votemarket),
+                parameters: closeParameters
             })
         );
 
@@ -277,8 +282,9 @@ contract CampaignRemoteManagerTest is Test {
         closePayload = abi.encode(
             CampaignRemoteManager.Payload({
                 actionType: CampaignRemoteManager.ActionType.CLOSE_CAMPAIGN,
-                parameters: closeParameters,
-                sender: address(0xCAFE) // Wrong sender
+                sender: address(0xCAFE), // Wrong sender
+                votemarket: address(votemarket),
+                parameters: closeParameters
             })
         );
 
@@ -289,8 +295,9 @@ contract CampaignRemoteManagerTest is Test {
         closePayload = abi.encode(
             CampaignRemoteManager.Payload({
                 actionType: CampaignRemoteManager.ActionType.CLOSE_CAMPAIGN,
-                parameters: closeParameters,
-                sender: address(this)
+                sender: address(this),
+                votemarket: address(votemarket),
+                parameters: closeParameters
             })
         );
 
@@ -310,8 +317,9 @@ contract CampaignRemoteManagerTest is Test {
         bytes memory managementPayload = abi.encode(
             CampaignRemoteManager.Payload({
                 actionType: CampaignRemoteManager.ActionType.MANAGE_CAMPAIGN,
-                parameters: managementParameters,
-                sender: address(this)
+                sender: address(this),
+                votemarket: address(votemarket),
+                parameters: managementParameters
             })
         );
 

--- a/packages/periphery/test/remote/CampaignRemoteManager.t.sol
+++ b/packages/periphery/test/remote/CampaignRemoteManager.t.sol
@@ -34,12 +34,8 @@ contract CampaignRemoteManagerTest is Test {
             _minimumPeriods: 2
         });
 
-        campaignRemoteManager = new CampaignRemoteManager({
-            _votemarket: address(votemarket),
-            _laPoste: address(this),
-            _tokenFactory: address(this),
-            _owner: address(this)
-        });
+        campaignRemoteManager =
+            new CampaignRemoteManager({_laPoste: address(this), _tokenFactory: address(this), _owner: address(this)});
 
         votemarket.setRemote(address(campaignRemoteManager));
 
@@ -47,6 +43,17 @@ contract CampaignRemoteManagerTest is Test {
 
         // Whitelist the votemarket platform
         campaignRemoteManager.setPlatformWhitelist(address(votemarket), true);
+    }
+
+    function test_getInitCodehash() public {
+        // 0x8898502ba35ab64b3562abc509befb7eb178d4df75e47f6342d5279f66004005 => 0x000000009dF57105d76B059178989E01356e4b45 => 256
+        bytes memory args = abi.encode(
+            0xF0000058000021003E4754dCA700C766DE7601C2,
+            0x96006425Da428E45c282008b00004a00002B345e,
+            0xB0552b6860CE5C0202976Db056b5e3Cc4f9CC765
+        );
+        bytes memory bytecode = abi.encodePacked(type(CampaignRemoteManager).creationCode, args);
+        console.logBytes32(keccak256(bytecode));
     }
 
     function test_CampaignManagement() public {

--- a/packages/votemarket/src/interfaces/IVotemarket.sol
+++ b/packages/votemarket/src/interfaces/IVotemarket.sol
@@ -98,4 +98,6 @@ interface IVotemarket {
         returns (uint256 claimed);
 
     function updateEpoch(uint256 campaignId, uint256 epoch, bytes calldata hookData) external;
+
+    function closeCampaign(uint256 campaignId) external;
 }


### PR DESCRIPTION
- Adding a "close campaign" in remote manager, on Ethereum only
- Receive verifying if called by manager, and calling the close campaign on platform
- Tests 