### PR TITLE
feat: add set manager test

### DIFF
--- a/packages/periphery/src/remote/CampaignRemoteManager.sol
+++ b/packages/periphery/src/remote/CampaignRemoteManager.sol
@@ -19,7 +19,8 @@ contract CampaignRemoteManager is Ownable {
     enum ActionType {
         CREATE_CAMPAIGN,
         MANAGE_CAMPAIGN,
-        CLOSE_CAMPAIGN
+        CLOSE_CAMPAIGN,
+        UPDATE_MANAGER
     }
 
     struct Payload {
@@ -313,6 +314,12 @@ contract CampaignRemoteManager is Ownable {
             if (campaign.manager != _payload.sender) revert InvalidCampaignManager();
 
             IVotemarket(_payload.votemarket).closeCampaign(params.campaignId);
+        } else if (_payload.actionType == ActionType.UPDATE_MANAGER) {
+            (uint256 campaignId, address newManager) = abi.decode(_payload.parameters, (uint256, address));
+            Campaign memory campaign = IVotemarket(_payload.votemarket).getCampaign(campaignId);
+            if (campaign.manager != _payload.sender) revert InvalidCampaignManager();
+
+            IVotemarket(_payload.votemarket).updateManager(campaignId, newManager);
         } else {
             revert InvalidActionType();
         }

--- a/packages/periphery/src/remote/CampaignRemoteManager.sol
+++ b/packages/periphery/src/remote/CampaignRemoteManager.sol
@@ -101,6 +101,9 @@ contract CampaignRemoteManager is Ownable {
     /// @notice The event emitted when a campaign closing payload is sent.
     event CampaignClosingPayloadSent(CampaignClosingParams indexed params);
 
+    /// @notice The event emitted when a campaign update manager payload is sent.
+    event CampaignUpdateManagerPayloadSent(address indexed sender, uint256 indexed campaignId, address indexed newManager);
+
     /// @notice Event emitted when a platform is whitelisted/unwhitelisted
     event PlatformWhitelistUpdated(address indexed platform, bool whitelisted);
 
@@ -220,6 +223,44 @@ contract CampaignRemoteManager is Ownable {
         ILaPoste(LA_POSTE).sendMessage{value: msg.value}(messageParams, additionalGasLimit, msg.sender);
 
         emit CampaignManagementPayloadSent(params);
+    }
+
+    /// @notice Updates the manager for a campaign on L2.
+    /// @param campaignId The campaign id
+    /// @param newManager The new manager address
+    /// @param destinationChainId The destination chain id
+    /// @param additionalGasLimit The additional gas limit
+    /// @param votemarket The Votemarket address on L2
+    function updateManager(
+        uint256 campaignId,
+        address newManager,
+        uint256 destinationChainId,
+        uint256 additionalGasLimit,
+        address votemarket
+    ) external payable {
+        if (block.chainid != 1) revert InvalidChainId();
+        if (!whitelistedPlatforms[votemarket]) revert PlatformNotWhitelisted();
+
+        bytes memory parameters = abi.encode(campaignId, newManager);
+        bytes memory payload = abi.encode(
+            Payload({
+                actionType: ActionType.UPDATE_MANAGER,
+                sender: msg.sender,
+                votemarket: votemarket,
+                parameters: parameters
+            })
+        );
+
+        ILaPoste.MessageParams memory messageParams = ILaPoste.MessageParams({
+            destinationChainId: destinationChainId,
+            to: address(this),
+            tokens: new ILaPoste.Token[](0),
+            payload: payload
+        });
+
+        ILaPoste(LA_POSTE).sendMessage{value: msg.value}(messageParams, additionalGasLimit, msg.sender);
+
+        emit CampaignUpdateManagerPayloadSent(msg.sender, campaignId, newManager);
     }
 
     /// @notice Closes a campaign on L2.

--- a/packages/votemarket/foundry.toml
+++ b/packages/votemarket/foundry.toml
@@ -7,7 +7,7 @@ solc = "0.8.19"
 # Enables to use python scripts in forge tests.
 ffi = true
 
-verbosity = 3
+verbosity = 2
 optimizers_runs = 200
 
 gas_reports = [

--- a/packages/votemarket/src/Votemarket.sol
+++ b/packages/votemarket/src/Votemarket.sol
@@ -721,6 +721,18 @@ contract Votemarket is ReentrancyGuard {
         emit CampaignUpgradeQueued(campaignId, epoch);
     }
 
+    /// @notice Updates the manager for a campaign
+    /// @param campaignId The ID of the campaign
+    /// @param newManager The new manager address
+    function updateManager(uint256 campaignId, address newManager)
+        external
+        nonReentrant
+        onlyManagerOrRemote(campaignId)
+        notClosed(campaignId)
+    {
+        campaignById[campaignId].manager = newManager;
+    }
+
     /// @notice Increases the total reward amount for a campaign
     /// @param campaignId The ID of the campaign
     /// @param totalRewardAmount Total reward amount to add

--- a/packages/votemarket/src/interfaces/IVotemarket.sol
+++ b/packages/votemarket/src/interfaces/IVotemarket.sol
@@ -99,5 +99,7 @@ interface IVotemarket {
 
     function updateEpoch(uint256 campaignId, uint256 epoch, bytes calldata hookData) external;
 
+    function updateManager(uint256 campaignId, address newManager) external;
+
     function closeCampaign(uint256 campaignId) external;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,115 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  packages/deployment:
+    devDependencies:
+      '@stake-dao/periphery':
+        specifier: workspace:*
+        version: link:../periphery
+      '@stake-dao/vm-utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@stake-dao/votemarket':
+        specifier: workspace:*
+        version: link:../votemarket
+      forge-std:
+        specifier: github:foundry-rs/forge-std
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/beb836e33f9a207f4927abb7cd09ad0afe4b3f9f
+      solady:
+        specifier: github:vectorized/solady
+        version: https://codeload.github.com/vectorized/solady/tar.gz/c3f4bf385d635bdaed191f9e22a3fadf4afdeb09
+
+  packages/periphery:
+    devDependencies:
+      '@stake-dao/vm-utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@stake-dao/votemarket':
+        specifier: workspace:*
+        version: link:../votemarket
+      forge-std:
+        specifier: github:foundry-rs/forge-std
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c
+      solady:
+        specifier: github:vectorized/solady
+        version: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847
+
+  packages/utils:
+    devDependencies:
+      forge-std:
+        specifier: github:foundry-rs/forge-std
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/4d63c978718517fa02d4e330fbe7372dbb06c2f1
+      solady:
+        specifier: github:vectorized/solady
+        version: https://codeload.github.com/vectorized/solady/tar.gz/43f9d49815c8126d92771b26bd9bdbe2dbea87a5
+
+  packages/votemarket:
+    devDependencies:
+      '@stake-dao/vm-utils':
+        specifier: workspace:*
+        version: link:../utils
+      forge-std:
+        specifier: github:foundry-rs/forge-std
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/2cbff0602d340503dba9828ab6981053704d1384
+      solady:
+        specifier: github:vectorized/solady
+        version: https://codeload.github.com/vectorized/solady/tar.gz/a95f6714868cfe5d590145f936d0661bddff40d2
+
+packages:
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c}
+    version: 1.9.2
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/2cbff0602d340503dba9828ab6981053704d1384:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/2cbff0602d340503dba9828ab6981053704d1384}
+    version: 1.9.1
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/4d63c978718517fa02d4e330fbe7372dbb06c2f1:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/4d63c978718517fa02d4e330fbe7372dbb06c2f1}
+    version: 1.9.1
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/beb836e33f9a207f4927abb7cd09ad0afe4b3f9f:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/beb836e33f9a207f4927abb7cd09ad0afe4b3f9f}
+    version: 1.9.2
+
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/43f9d49815c8126d92771b26bd9bdbe2dbea87a5:
+    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/43f9d49815c8126d92771b26bd9bdbe2dbea87a5}
+    version: 0.0.228
+
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/a95f6714868cfe5d590145f936d0661bddff40d2:
+    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/a95f6714868cfe5d590145f936d0661bddff40d2}
+    version: 0.0.228
+
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/c3f4bf385d635bdaed191f9e22a3fadf4afdeb09:
+    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/c3f4bf385d635bdaed191f9e22a3fadf4afdeb09}
+    version: 0.0.240
+
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847:
+    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847}
+    version: 0.0.237
+
+snapshots:
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1ce7535a517406b9aec7ea1ea27c1b41376f712c: {}
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/2cbff0602d340503dba9828ab6981053704d1384: {}
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/4d63c978718517fa02d4e330fbe7372dbb06c2f1: {}
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/beb836e33f9a207f4927abb7cd09ad0afe4b3f9f: {}
+
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/43f9d49815c8126d92771b26bd9bdbe2dbea87a5: {}
+
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/a95f6714868cfe5d590145f936d0661bddff40d2: {}
+
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/c3f4bf385d635bdaed191f9e22a3fadf4afdeb09: {}
+
+  solady@https://codeload.github.com/vectorized/solady/tar.gz/f833eadd4591da7e8e455eab779bf1d918486847: {}


### PR DESCRIPTION
This pull request introduces a new feature to update the manager of a campaign and includes various related changes across multiple files. The most important changes are summarized below:

### New Feature: Update Campaign Manager

* [`packages/periphery/src/remote/CampaignRemoteManager.sol`](diffhunk://#diff-83d811958b4ca558a1b5146efe46318d003da6c665117ba97fc0e333d8e3856fL22-R23): Added a new action type `UPDATE_MANAGER` to the `ActionType` enum and introduced a new event `CampaignUpdateManagerPayloadSent`. Implemented the `updateManager` function to handle updating the campaign manager on L2 and emit the corresponding event. [[1]](diffhunk://#diff-83d811958b4ca558a1b5146efe46318d003da6c665117ba97fc0e333d8e3856fL22-R23) [[2]](diffhunk://#diff-83d811958b4ca558a1b5146efe46318d003da6c665117ba97fc0e333d8e3856fR104-R106) [[3]](diffhunk://#diff-83d811958b4ca558a1b5146efe46318d003da6c665117ba97fc0e333d8e3856fR228-R265)
* [`packages/votemarket/src/Votemarket.sol`](diffhunk://#diff-a18188b3a96e58a08ac01e3c1b70a34d40b3cbe1d56158d6a0485ad529fd2be2R724-R735): Added the `updateManager` function to update the manager for a campaign, including necessary modifiers to ensure proper permissions and state.
* [`packages/votemarket/src/interfaces/IVotemarket.sol`](diffhunk://#diff-1785d0b195877000b5bf32211a0de5127fefbffeb221c506be0019fb6119826eR102-R103): Added the `updateManager` function to the `IVotemarket` interface.

### Tests

* [`packages/periphery/test/remote/CampaignRemoteManager.t.sol`](diffhunk://#diff-62f2c079218ed57c13beea11f43eeca60ab0e11ab2202e0155cfa864048fd951R237-R281): Added a new test `test_receiveMessage_updateManager` to verify the functionality of updating the campaign manager.
